### PR TITLE
Fetch catalog data on server and seed client manager

### DIFF
--- a/app/(owner)/catalog/page.tsx
+++ b/app/(owner)/catalog/page.tsx
@@ -1,20 +1,45 @@
-import { requireOwnerAuth } from "@/lib/auth-utils";
 import { CatalogManager } from "@/components/catalog/catalog-manager";
+import { requireOwnerAuth } from "@/lib/auth-utils";
+import { getOwnerCatalog } from "@/lib/catalog";
 
 export default async function CatalogPage() {
   // This will redirect to /owner-sign-in if not authenticated or not an owner
-  await requireOwnerAuth();
+  const session = await requireOwnerAuth();
 
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">Catalog</h1>
-        <p className="text-muted-foreground">
-          Manage your services and categories
-        </p>
+  try {
+    const { categories, uncategorizedServices } = await getOwnerCatalog(session.user.id);
+
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Catalog</h1>
+          <p className="text-muted-foreground">
+            Manage your services and categories
+          </p>
+        </div>
+
+        <CatalogManager
+          categories={categories}
+          uncategorizedServices={uncategorizedServices}
+        />
       </div>
-      
-      <CatalogManager />
-    </div>
-  )
+    );
+  } catch (error) {
+    console.error("Error loading catalog page:", error);
+
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Catalog</h1>
+          <p className="text-muted-foreground">
+            Manage your services and categories
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-6 text-destructive">
+          Failed to load catalog data. Please try again later.
+        </div>
+      </div>
+    );
+  }
 }

--- a/components/catalog/catalog-manager.tsx
+++ b/components/catalog/catalog-manager.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CatalogTable } from "./catalog-table";
 import { CategoryForm } from "./category-form";
 import { ServiceForm } from "./service-form";
-import { getCatalogData } from "@/app/actions/catalog";
 import { FiPlus } from "react-icons/fi";
 import toast from "react-hot-toast";
+
+import { getCatalogData } from "@/app/actions/catalog";
 
 interface Category {
   id: string;
@@ -29,14 +30,25 @@ interface Service {
   } | null;
 }
 
-export function CatalogManager() {
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [uncategorizedServices, setUncategorizedServices] = useState<Service[]>([]);
-  const [loading, setLoading] = useState(true);
+interface CatalogManagerProps {
+  categories: Category[];
+  uncategorizedServices: Service[];
+}
+
+export function CatalogManager({
+  categories: initialCategories,
+  uncategorizedServices: initialUncategorizedServices,
+}: CatalogManagerProps) {
+  const [categories, setCategories] = useState<Category[]>(initialCategories);
+  const [uncategorizedServices, setUncategorizedServices] = useState<Service[]>(
+    initialUncategorizedServices,
+  );
+  const [loading, setLoading] = useState(false);
   const [showCategoryForm, setShowCategoryForm] = useState(false);
   const [showServiceForm, setShowServiceForm] = useState(false);
 
   const loadData = async () => {
+    setLoading(true);
     try {
       const result = await getCatalogData();
       if (result.success && result.data) {
@@ -52,14 +64,12 @@ export function CatalogManager() {
     }
   };
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
   const allCategories = categories.map(cat => ({ id: cat.id, name: cat.name }));
   const totalServices = categories.reduce((sum, cat) => sum + cat.services.length, 0) + uncategorizedServices.length;
 
-  if (loading) {
+  const hasCatalogContent = categories.length > 0 || uncategorizedServices.length > 0;
+
+  if (loading && !hasCatalogContent) {
     return (
       <div className="space-y-6">
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">

--- a/lib/catalog.ts
+++ b/lib/catalog.ts
@@ -1,0 +1,31 @@
+import prisma from "@/db";
+import { getOwnerSalonOrThrow } from "@/lib/user-utils";
+
+export async function getOwnerCatalog(userId: string) {
+  const salon = await getOwnerSalonOrThrow(userId);
+
+  const [categories, uncategorizedServices] = await Promise.all([
+    prisma.serviceCategory.findMany({
+      where: { salonId: salon.id },
+      include: {
+        services: {
+          orderBy: { name: "asc" },
+        },
+      },
+      orderBy: { order: "asc" },
+    }),
+    prisma.service.findMany({
+      where: {
+        salonId: salon.id,
+        categoryId: null,
+      },
+      orderBy: { name: "asc" },
+    }),
+  ]);
+
+  return {
+    salon,
+    categories,
+    uncategorizedServices,
+  };
+}

--- a/lib/user-utils.ts
+++ b/lib/user-utils.ts
@@ -79,3 +79,14 @@ export async function getUserSalons(userId: string, role?: Role) {
 
   return memberships.map(m => m.salon);
 }
+
+export async function getOwnerSalonOrThrow(userId: string) {
+  const salons = await getUserSalons(userId, "OWNER");
+  const salon = salons[0];
+
+  if (!salon) {
+    throw new Error("No salon found for user");
+  }
+
+  return salon;
+}


### PR DESCRIPTION
## Summary
- load catalog data for owners on the server page using the shared helper
- add helpers to resolve an owner's salon and shared catalog retrieval
- seed the catalog manager with initial data and refresh only after mutations

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cbd9b99f20832bb298ae01813658c2